### PR TITLE
Implement connection health checks for rust-cueball.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,14 +5,15 @@ authors = ["Kelly McLaughlin <kelly.mclaughlin@joyent.com>"]
 edition = "2018"
 
 [dependencies]
-cueball = { path = '../rust-cueball' }
+cueball = { git = 'https://github.com/joyent/rust-cueball', branch = "MANTA-4630" }
 native-tls = "0.2.3"
 postgres = "0.16.0-rc.1"
 serde = "1.0.84"
 serde_derive = "1.0.84"
 tokio-postgres-native-tls = "0.1.0-rc.1"
+unicode-normalization = "=0.1.5"
 
 [dev-dependencies]
-cueball-static-resolver = { path = "../cueball-static-resolver", tag = "v0.2.0" }
+cueball-static-resolver = { git = "https://github.com/joyent/cueball-static-resolver", branch = "MANTA-4630" }
 slog = "2.4.1"
 slog-term = "2.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Kelly McLaughlin <kelly.mclaughlin@joyent.com>"]
 edition = "2018"
 
 [dependencies]
-cueball = { git = 'https://github.com/joyent/rust-cueball', branch = "MANTA-4630" }
+cueball = { path = '../rust-cueball' }
 native-tls = "0.2.3"
 postgres = "0.16.0-rc.1"
 serde = "1.0.84"
@@ -14,6 +14,6 @@ tokio-postgres-native-tls = "0.1.0-rc.1"
 unicode-normalization = "=0.1.5"
 
 [dev-dependencies]
-cueball-static-resolver = { git = "https://github.com/joyent/cueball-static-resolver", branch = "MANTA-4630" }
+cueball-static-resolver = { git = "https://github.com/joyent/cueball-static-resolver",  tag = "v0.2.2"  }
 slog = "2.4.1"
 slog-term = "2.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Kelly McLaughlin <kelly.mclaughlin@joyent.com>"]
 edition = "2018"
 
 [dependencies]
-cueball = { path = '../rust-cueball' }
+cueball = { git = 'https://github.com/joyent/rust-cueball', tag = "v0.3.0" }
 native-tls = "0.2.3"
 postgres = "0.16.0-rc.1"
 serde = "1.0.84"
@@ -14,6 +14,6 @@ tokio-postgres-native-tls = "0.1.0-rc.1"
 unicode-normalization = "=0.1.5"
 
 [dev-dependencies]
-cueball-static-resolver = { git = "https://github.com/joyent/cueball-static-resolver",  tag = "v0.2.2"  }
+cueball-static-resolver = { git = "https://github.com/joyent/cueball-static-resolver",  tag = "v0.2.0"  }
 slog = "2.4.1"
 slog-term = "2.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cueball-postgres-connection"
-version = "0.1.1"
+version = "0.3.0"
 authors = ["Kelly McLaughlin <kelly.mclaughlin@joyent.com>"]
 edition = "2018"
 
@@ -14,6 +14,6 @@ tokio-postgres-native-tls = "0.1.0-rc.1"
 unicode-normalization = "=0.1.5"
 
 [dev-dependencies]
-cueball-static-resolver = { git = "https://github.com/joyent/cueball-static-resolver", tag = "v0.2.0" }
+cueball-static-resolver = { git = "https://github.com/joyent/cueball-static-resolver", tag = "v0.3.0" }
 slog = "2.4.1"
 slog-term = "2.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Kelly McLaughlin <kelly.mclaughlin@joyent.com>"]
 edition = "2018"
 
 [dependencies]
-cueball = { git = 'https://github.com/joyent/rust-cueball', tag = "v0.2.1" }
+cueball = { path = '../rust-cueball' }
 native-tls = "0.2.3"
 postgres = "0.16.0-rc.1"
 serde = "1.0.84"
@@ -13,6 +13,6 @@ serde_derive = "1.0.84"
 tokio-postgres-native-tls = "0.1.0-rc.1"
 
 [dev-dependencies]
-cueball-static-resolver = { git = "https://github.com/joyent/cueball-static-resolver", tag = "v0.2.0" }
+cueball-static-resolver = { path = "../cueball-static-resolver", tag = "v0.2.0" }
 slog = "2.4.1"
 slog-term = "2.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,6 @@ tokio-postgres-native-tls = "0.1.0-rc.1"
 unicode-normalization = "=0.1.5"
 
 [dev-dependencies]
-cueball-static-resolver = { git = "https://github.com/joyent/cueball-static-resolver",  tag = "v0.2.0"  }
+cueball-static-resolver = { git = "https://github.com/joyent/cueball-static-resolver", tag = "v0.2.0" }
 slog = "2.4.1"
 slog-term = "2.4.0"

--- a/examples/postgres_connection_pool.rs
+++ b/examples/postgres_connection_pool.rs
@@ -12,11 +12,7 @@ use slog::{o, Drain, Logger};
 
 use cueball::connection_pool::types::ConnectionPoolOptions;
 use cueball::connection_pool::ConnectionPool;
-use cueball_postgres_connection::{
-    PostgresConnection,
-    PostgresConnectionConfig,
-    TlsConfig
-};
+use cueball_postgres_connection::{PostgresConnection, PostgresConnectionConfig, TlsConfig};
 use cueball_static_resolver::StaticIpResolver;
 
 fn main() {
@@ -40,7 +36,7 @@ fn main() {
         port: None,
         database: Some(database.into()),
         application_name: Some(application_name.into()),
-        tls_config: TlsConfig::disable()
+        tls_config: TlsConfig::disable(),
     };
     let connection_creator = PostgresConnection::connection_creator(pg_config);
     let pool_opts = ConnectionPoolOptions {
@@ -48,7 +44,7 @@ fn main() {
         claim_timeout: None,
         log: Some(log),
         rebalancer_action_delay: None,
-        decoherence_interval: None
+        decoherence_interval: None,
     };
 
     let _pool = ConnectionPool::new(pool_opts, resolver, connection_creator);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,18 +15,16 @@ use tokio_postgres_native_tls::MakeTlsConnector;
 use cueball::backend::Backend;
 use cueball::connection::Connection;
 
-pub struct PostgresConnection
-{
+pub struct PostgresConnection {
     pub connection: Option<Client>,
     url: String,
     tls_config: TlsConfig,
     connected: bool,
 }
 
-impl PostgresConnection
-{
+impl PostgresConnection {
     pub fn connection_creator<'a>(
-        mut config: PostgresConnectionConfig
+        mut config: PostgresConnectionConfig,
     ) -> impl FnMut(&Backend) -> PostgresConnection + 'a {
         move |b| {
             config.host = Some(b.address.to_string());
@@ -38,39 +36,45 @@ impl PostgresConnection
                 connection: None,
                 url,
                 tls_config: config.tls_config.clone(),
-                connected: false
+                connected: false,
             }
         }
     }
 }
 
-impl Connection for PostgresConnection
-{
+impl Connection for PostgresConnection {
     type Error = postgres::Error;
 
     fn connect(&mut self) -> Result<(), Self::Error> {
-
         let tls_connector = make_tls_connector(&self.tls_config);
-        let connection =
-            if tls_connector.is_some() {
-                Client::connect(&self.url, tls_connector.unwrap())?
-            } else {
-                Client::connect(&self.url, NoTls)?
-            };
+        let connection = if tls_connector.is_some() {
+            Client::connect(&self.url, tls_connector.unwrap())?
+        } else {
+            Client::connect(&self.url, NoTls)?
+        };
         self.connection = Some(connection);
         self.connected = true;
         Ok(())
     }
 
     fn is_valid(&mut self) -> bool {
-        match self.connection.as_mut().unwrap().simple_query("").map(|_| ()) {
+        match self
+            .connection
+            .as_mut()
+            .unwrap()
+            .simple_query("")
+            .map(|_| ())
+        {
             Ok(_) => true,
-            Err(_) => false
+            Err(_) => false,
         }
     }
 
-    fn has_broken(&mut self) -> bool {
-        self.connection.as_mut().unwrap().is_closed()
+    fn has_broken(&self) -> bool {
+        match &self.connection {
+            Some(conn) => conn.is_closed(),
+            None => false,
+        }
     }
 
     fn close(&mut self) -> Result<(), Self::Error> {
@@ -80,8 +84,7 @@ impl Connection for PostgresConnection
     }
 }
 
-impl Deref for PostgresConnection
-{
+impl Deref for PostgresConnection {
     type Target = Client;
 
     fn deref(&self) -> &Client {
@@ -89,31 +92,27 @@ impl Deref for PostgresConnection
     }
 }
 
-impl DerefMut for PostgresConnection
-{
+impl DerefMut for PostgresConnection {
     fn deref_mut(&mut self) -> &mut Client {
         self.connection.as_mut().unwrap()
     }
 }
 
 #[derive(Clone)]
-pub struct PostgresConnectionConfig
-{
+pub struct PostgresConnectionConfig {
     pub user: Option<String>,
     pub password: Option<String>,
     pub host: Option<String>,
     pub port: Option<u16>,
     pub database: Option<String>,
     pub application_name: Option<String>,
-    pub tls_config: TlsConfig
+    pub tls_config: TlsConfig,
 }
 
-impl From<PostgresConnectionConfig> for String
-{
+impl From<PostgresConnectionConfig> for String {
     fn from(config: PostgresConnectionConfig) -> Self {
         let scheme = "postgresql://";
         let user = config.user.unwrap_or_else(|| "".into());
-
 
         let at = if user.is_empty() { "" } else { "@" };
 
@@ -129,7 +128,8 @@ impl From<PostgresConnectionConfig> for String
 
         let slash = if database.is_empty() { "" } else { "/" };
 
-        let application_name = config.application_name.unwrap_or_else(|| "".into());
+        let application_name =
+            config.application_name.unwrap_or_else(|| "".into());
         let question_mark = "?";
 
         let app_name_param = if application_name.is_empty() {
@@ -158,7 +158,7 @@ impl From<PostgresConnectionConfig> for String
             app_name_param,
             application_name.as_str(),
             ssl_mode_param,
-            ssl_mode.as_str()
+            ssl_mode.as_str(),
         ]
         .concat()
     }
@@ -177,18 +177,18 @@ pub enum TlsConnectMode {
     #[serde(alias = "verify-ca")]
     VerifyCa,
     #[serde(alias = "verify-full")]
-    VerifyFull
+    VerifyFull,
 }
 
 impl ToString for TlsConnectMode {
     fn to_string(&self) -> String {
         match self {
-            TlsConnectMode::Disable    => String::from("disable"),
-            TlsConnectMode::Allow      => String::from("allow"),
-            TlsConnectMode::Prefer     => String::from("prefer"),
-            TlsConnectMode::Require    => String::from("require"),
-            TlsConnectMode::VerifyCa   => String::from("verify-ca"),
-            TlsConnectMode::VerifyFull => String::from("verify-full")
+            TlsConnectMode::Disable => String::from("disable"),
+            TlsConnectMode::Allow => String::from("allow"),
+            TlsConnectMode::Prefer => String::from("prefer"),
+            TlsConnectMode::Require => String::from("require"),
+            TlsConnectMode::VerifyCa => String::from("verify-ca"),
+            TlsConnectMode::VerifyFull => String::from("verify-full"),
         }
     }
 }
@@ -200,58 +200,56 @@ pub type Certificate = NativeCertificate;
 pub type CertificateError = NativeError;
 
 #[derive(Clone)]
-pub struct TlsConfig
-{
+pub struct TlsConfig {
     pub(self) mode: TlsConnectMode,
-    pub(self) certificate: Option<Certificate>
+    pub(self) certificate: Option<Certificate>,
 }
 
 impl TlsConfig {
     pub fn disable() -> Self {
         TlsConfig {
             mode: TlsConnectMode::Disable,
-            certificate: None
+            certificate: None,
         }
     }
 
     pub fn allow(certificate: Option<Certificate>) -> Self {
         TlsConfig {
             mode: TlsConnectMode::Allow,
-            certificate
+            certificate,
         }
     }
 
     pub fn prefer(certificate: Option<Certificate>) -> Self {
         TlsConfig {
             mode: TlsConnectMode::Prefer,
-            certificate
+            certificate,
         }
     }
 
     pub fn require(certificate: Certificate) -> Self {
         TlsConfig {
             mode: TlsConnectMode::Require,
-            certificate: Some(certificate)
+            certificate: Some(certificate),
         }
     }
 
     pub fn verify_ca(certificate: Certificate) -> Self {
         TlsConfig {
             mode: TlsConnectMode::VerifyCa,
-            certificate: Some(certificate)
+            certificate: Some(certificate),
         }
     }
 
     pub fn verify_full(certificate: Certificate) -> Self {
         TlsConfig {
             mode: TlsConnectMode::VerifyFull,
-            certificate: Some(certificate)
+            certificate: Some(certificate),
         }
     }
 }
 
-fn make_tls_connector(tls_config: &TlsConfig) -> Option<MakeTlsConnector>
-{
+fn make_tls_connector(tls_config: &TlsConfig) -> Option<MakeTlsConnector> {
     let m_cert = tls_config.certificate.clone();
     match tls_config.mode {
         TlsConnectMode::Disable => None,
@@ -264,12 +262,14 @@ fn make_tls_connector(tls_config: &TlsConfig) -> Option<MakeTlsConnector>
                 let connector = MakeTlsConnector::new(connector);
                 Some(connector)
             })
-        },
-        TlsConnectMode::Require |
-        TlsConnectMode::VerifyCa |
-        TlsConnectMode::VerifyFull => {
-            let cert = m_cert.expect("A certificate is required for require, \
-                                      verify-ca, and verify-full SSL modes");
+        }
+        TlsConnectMode::Require
+        | TlsConnectMode::VerifyCa
+        | TlsConnectMode::VerifyFull => {
+            let cert = m_cert.expect(
+                "A certificate is required for require, \
+                 verify-ca, and verify-full SSL modes",
+            );
             let connector = TlsConnector::builder()
                 .add_root_certificate(cert)
                 .build()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,17 @@ impl Connection for PostgresConnection
         Ok(())
     }
 
+    fn is_valid(&mut self) -> bool {
+        match self.connection.as_mut().unwrap().simple_query("").map(|_| ()) {
+            Ok(_) => true,
+            Err(_) => false
+        }
+    }
+
+    fn has_broken(&mut self) -> bool {
+        self.connection.as_mut().unwrap().is_closed()
+    }
+
     fn close(&mut self) -> Result<(), Self::Error> {
         self.connection = None;
         self.connected = false;
@@ -266,5 +277,4 @@ fn make_tls_connector(tls_config: &TlsConfig) -> Option<MakeTlsConnector>
             Some(MakeTlsConnector::new(connector))
         }
     }
-
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,8 +128,7 @@ impl From<PostgresConnectionConfig> for String {
 
         let slash = if database.is_empty() { "" } else { "/" };
 
-        let application_name =
-            config.application_name.unwrap_or_else(|| "".into());
+        let application_name = config.application_name.unwrap_or_else(|| "".into());
         let question_mark = "?";
 
         let app_name_param = if application_name.is_empty() {
@@ -253,19 +252,15 @@ fn make_tls_connector(tls_config: &TlsConfig) -> Option<MakeTlsConnector> {
     let m_cert = tls_config.certificate.clone();
     match tls_config.mode {
         TlsConnectMode::Disable => None,
-        TlsConnectMode::Allow | TlsConnectMode::Prefer => {
-            m_cert.and_then(|cert| {
-                let connector = TlsConnector::builder()
-                    .add_root_certificate(cert)
-                    .build()
-                    .unwrap();
-                let connector = MakeTlsConnector::new(connector);
-                Some(connector)
-            })
-        }
-        TlsConnectMode::Require
-        | TlsConnectMode::VerifyCa
-        | TlsConnectMode::VerifyFull => {
+        TlsConnectMode::Allow | TlsConnectMode::Prefer => m_cert.and_then(|cert| {
+            let connector = TlsConnector::builder()
+                .add_root_certificate(cert)
+                .build()
+                .unwrap();
+            let connector = MakeTlsConnector::new(connector);
+            Some(connector)
+        }),
+        TlsConnectMode::Require | TlsConnectMode::VerifyCa | TlsConnectMode::VerifyFull => {
             let cert = m_cert.expect(
                 "A certificate is required for require, \
                  verify-ca, and verify-full SSL modes",


### PR DESCRIPTION
Implement health checks using the new rust-cueball::Connection methods:
- `is_valid`
- `has_broken`

So that rust-cueball can manage postgres connections and determine of they are valid or have broken and need to be removed from the pool.

Associated rust-cueball PR: https://github.com/joyent/rust-cueball/pull/17